### PR TITLE
Make faces inherit from git-gutter+

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,16 @@ Features smaller, greyscale diff symbols. Activate it with
 
 ![git-gutter-fringe-customize](images/git-gutter-fringe-customize.png)
 
-You can change faces like following.
+You can customize the colors of modified, added, and deleted fringe marks either by modifying the faces from git-gutter+ or directly using the git-gutter-fr+ faces:
 
+Using the fact git-gutter-fr+ faces are inherited from git-gutter+:
+```elisp
+(set-face-foreground 'git-gutter+-modified "yellow")
+(set-face-foreground 'git-gutter+-added    "blue")
+(set-face-foreground 'git-gutter+-deleted  "white")
+```
+
+Or directly, to allow different colors for git-gutter-fr+ and git-gutter+:
 ```elisp
 (set-face-foreground 'git-gutter-fr+-modified "yellow")
 (set-face-foreground 'git-gutter-fr+-added    "blue")

--- a/git-gutter-fringe+.el
+++ b/git-gutter-fringe+.el
@@ -31,17 +31,17 @@
 (require 'fringe-helper)
 
 (defface git-gutter-fr+-modified
-    '((t (:foreground "magenta" :weight bold)))
+    '((t (:inherit git-gutter+-modified)))
   "Face of modified"
   :group 'git-gutter+)
 
 (defface git-gutter-fr+-added
-    '((t (:foreground "green" :weight bold)))
+    '((t (:inherit git-gutter+-added)))
   "Face of added"
   :group 'git-gutter+)
 
 (defface git-gutter-fr+-deleted
-    '((t (:foreground "red" :weight bold)))
+    '((t (:inherit git-gutter+-deleted)))
   "Face of deleted"
   :group 'git-gutter+)
 


### PR DESCRIPTION
Theme designers shouldn't have to support both git-gutter+ and
git-gutter-fringe+ separately unless they really want to, and we don't
need to define the color scheme for add, modified, and deleted in two
separate places when they're identical.
